### PR TITLE
add more commented-out Feff calculation cards with parameter hints

### DIFF
--- a/larixite/cif_cluster.py
+++ b/larixite/cif_cluster.py
@@ -79,7 +79,7 @@ class CIF_Cluster():
 
     """
     def __init__(self, ciftext=None, filename=None, absorber=None,
-                 absorber_site=1, with_h=False, cluster_size=8.0):
+                 absorber_site=1, with_h=False, cluster_size=10.0):
         self.filename = filename
         self.ciftext = ciftext
         self.set_absorber(absorber)
@@ -238,9 +238,10 @@ class CIF_Cluster():
         self.molecule = Molecule(self.symbols, self.coords)
 
 
-def cif_cluster(ciftext=None, filename=None, absorber=None):
+def cif_cluster(ciftext=None, filename=None, absorber=None, cluster_size=10.0):
     "return list of sites for the structure"
-    return CIF_Cluster(ciftext=ciftext, filename=filename, absorber=absorber)
+    return CIF_Cluster(ciftext=ciftext, filename=filename,
+                       absorber=absorber, cluster_size=cluster_size)
 
 
 def cif_extra_titles(cifid):
@@ -319,11 +320,10 @@ def cif2feffinp(ciftext, absorber, template=None, edge=None, cluster_size=8.0,
     if template is None:
         template = open(Path(TEMPLATE_FOLDER, 'feff_exafs.tmpl'), 'r').read()
 
-    cluster = CIF_Cluster(ciftext=ciftext, absorber=absorber)
+    cluster = CIF_Cluster(ciftext=ciftext, absorber=absorber, cluster_size=cluster_size+0.5)
 
     if absorber_site is None:
         absorber_site = cluster.atom_sites[absorber][0]
-
     cluster.build_cluster(absorber_site=absorber_site, cluster_size=cluster_size)
 
     mol = cluster.molecule
@@ -412,8 +412,6 @@ def cif2feffinp(ciftext, absorber, template=None, edge=None, cluster_size=8.0,
     atoms = []
     for dist, x, y, z, ipot, sym, tag in sorted(at_lines, key=lambda x: x[0]):
         acount += 1
-        if acount > 500:
-            break
         sym = (sym + ' ')[:2]
         xyzi = f'  {x:+.5f}  {y:+.5f}  {z:+.5f} {ipot:2d}'.replace(' +', '  ')
         atoms.append(f'{xyzi}  {sym:>3s}  {dist:.5f}  * {tag:s}')

--- a/larixite/cif_cluster.py
+++ b/larixite/cif_cluster.py
@@ -402,19 +402,20 @@ def cif2feffinp(ciftext, absorber, template=None, edge=None, cluster_size=8.0,
 
     # ipots
     ipot, z = 0, absorber_z
-    ipot_lines = [f'  {ipot:4d}  {z:>4d}   {absorber:>3s}']
+    ipot_lines = [f'  {ipot:4d}  {z:>4d}   {absorber:>3s}      -1     -1       0.01']
     for sym, ipot in ipot_map.items():
         z = atomic_number(sym)
-        ipot_lines.append(f'  {ipot:4d}  {z:>4d}   {sym:>3s}')
+        ipot_lines.append(f'  {ipot:4d}  {z:>4d}   {sym:>3s}      -1     -1')
 
     # ordered atoms list
     acount = 0
     atoms = []
     for dist, x, y, z, ipot, sym, tag in sorted(at_lines, key=lambda x: x[0]):
-        acount += 1
         sym = (sym + ' ')[:2]
-        xyzi = f'  {x:+.5f}  {y:+.5f}  {z:+.5f} {ipot:2d}'.replace(' +', '  ')
-        atoms.append(f'{xyzi}  {sym:>3s}  {dist:.5f}  * {tag:s}')
+        tag = (tag + '      ')[:7]
+        xyzi = f'  {x:+9.5f}  {y:+9.5f}  {z:+9.5f} {ipot:2d}'.replace(' +', '  ')
+        atoms.append(f'{xyzi}  {sym:>3s}  {dist:9.5f}  * {tag:s}  {acount:4d}')
+        acount += 1
 
 
     # now ready to write with template

--- a/larixite/templates/feff_exafs.tmpl
+++ b/larixite/templates/feff_exafs.tmpl
@@ -18,8 +18,8 @@ PRINT     1      0      0      0      0      3
 ** ixc = 0 means to use Hedin-Lundqvist, 1 to use Dirac-Hara
 ** vr = added (real) energy shift
 ** vi = added imaginary energy shift (broadening)
-*         ixc  [ Vr  Vi ]
-EXCHANGE  0
+*         ixc   vr  vi
+EXCHANGE  0     0.0  0.0
 
 RPATH     {radius}
 EXAFS     20

--- a/larixite/templates/feff_exafs.tmpl
+++ b/larixite/templates/feff_exafs.tmpl
@@ -40,6 +40,7 @@ NLEG      6
 ** eimag = imaginary energy for broadening
 *LDOS      -30   20     0.1
 
+** XANES: calculate XANES
 ** kmax = upper limit of XANES calculation
 ** delta_k = step in k [Ang^-1] to use
 ** delta_e = step in energy [eV] to use.

--- a/larixite/templates/feff_exafs.tmpl
+++ b/larixite/templates/feff_exafs.tmpl
@@ -10,11 +10,14 @@
 EDGE      {edge}
 S02       1.0
 
-*         pot    xsph  fms   paths genfmt ff2chi
-CONTROL   1      1     1     1     1      1
-PRINT     1      0     0     0     0      3
+*         pot    xsph   fms    paths  genfmt ff2chi
+CONTROL   1      1      1      1      1      1
+PRINT     1      0      0      0      0      3
 
-*** ixc=0 means to use Hedin-Lundqvist
+** Exchange: energy-dependent exchange correlation potential
+** ixc = 0 means to use Hedin-Lundqvist, 1 to use Dirac-Hara
+** vr = added (real) energy shift
+** vi = added imaginary energy shift (broadening)
 *         ixc  [ Vr  Vi ]
 EXCHANGE  0
 
@@ -24,15 +27,36 @@ NLEG      6
 
 *  POLARIZATION  0 0 0
 
-*         r_scf  [ l_scf   n_scf   ca ]
+** SCF: self-consisent field for atomic potentials
+** r_scf = radius for self-consistent pots (2 shells is a good choice)
+** l_scf = 0 for a solid, 1 for a molecule
+** n_scf = max number of iterations to run. 0 for non-SCF, usually 10 is sufficient
+** ca = convergence factor (between 0 and 1). 1 is unstable, 0.2 is typical, lower values are more stable.
+**         r_scf  [ l_scf   n_scf   ca ]
 *SCF       5.0
 
-*         emin  emax   eimag
+** LDOS: local density of electronic states
+** emin, emax = energy range for DOS calculation, relative  to Ethreshold
+** eimag = imaginary energy for broadening
 *LDOS      -30   20     0.1
 
+** kmax = upper limit of XANES calculation
+** delta_k = step in k [Ang^-1] to use
+** delta_e = step in energy [eV] to use.
+**         kmax   [ delta_k  delta_e ]
+* XANES     4.0
+
+** FMS: full multiple scattering
+** r_fms = radius for full multiple scattering
+** l_fms = 0 for a solid, 1 for a molecule
+**        r_fms  l_fms
+* FMS     4.0     0
 
 POTENTIALS
-*  ipot    z    tag
+** l_scf - max l (ang momentum number) for SCF calculation, -1 for 'auto'
+** l_fms - max l (ang momentum number) for FMS calculation, -1 for 'auto'
+** stoichiometry = number of atoms with this ipot in unit cell (use 0.01 for ipot 0)
+**  ipot    z    tag    l_scf  l_fms   stoichiometry
 {potentials}
 
 ATOMS

--- a/larixite/templates/feff_exafs.tmpl
+++ b/larixite/templates/feff_exafs.tmpl
@@ -61,7 +61,7 @@ POTENTIALS
 {potentials}
 
 ATOMS
-*    x         y         z     ipot tag distance   site_info
+*     x          y          z     ipot tag   distance site_info  index
 {atoms}
 
 * END

--- a/larixite/webapp/templates/index.html
+++ b/larixite/webapp/templates/index.html
@@ -101,7 +101,8 @@
       <tr>
         <td><label for="cluster_size">Cluster Size (Ang): </label></td><td>
             <input style="width: 100px;" type="number" id="cluster_size"
-                   name="cluster_size" value="{{ cluster_size }}" step=0.1>
+                   name="cluster_size" value="{{ cluster_size }}"
+                   step=0.1 min=2.0 max=40.0>
         </td>
         <td  colspan=2>  <input type="checkbox" id="with_h" name="with_h"
                                {% if with_h  %} checked="checked" {% endif %}       >


### PR DESCRIPTION
This adds several lines to the Feff template to provide commented-out hints on how to modify it to run various calculations. 

This addresses #12.  Since it is adding only static text, it should not impact the creation of output files.   