### PR TITLE
Some FDMNES fixes

### DIFF
--- a/larixite/fdmnes.py
+++ b/larixite/fdmnes.py
@@ -61,10 +61,12 @@ class FdmnesXasInput:
     struct_type: Union[str, None] = None  #: type of the structure
     vmax: Union[float, None] = None  #: maximum potential value for molecules
     erange: str = "-20.0 0.1 70.0 1.0 100.0"  #: energy range
-    fileout_prefix: str = "job"  #: prefix of the output filename for the FDMNES job (extension: .inp)
+    fileout_prefix: str = (
+        "job"  #: prefix of the output filename for the FDMNES job (extension: .inp)
+    )
     tmplpath: Union[str, Path, None] = None  #: path to the FDMNES input template
     params: Union[dict[str, bool], None] = None  #: enable/disable parameters for FDMNES
-    spacer : str = "   "  #: spacer for the FDMNES input text
+    spacer: str = "   "  #: spacer for the FDMNES input text
 
     def __post_init__(self):
         """Validate and optimize attributes"""
@@ -320,7 +322,8 @@ class FdmnesXasInput:
         return strict_ascii(template.format(**conf))
 
     def write_input(
-        self, inputtext: Union[str, None] = None, outdir: Union[str, Path, None] = None) -> Path:
+        self, inputtext: Union[str, None] = None, outdir: Union[str, Path, None] = None
+    ) -> Path:
         """Write the FDMNES input text to disk and return the output directory"""
         if inputtext is None:
             inputtext = self.get_input()
@@ -351,6 +354,8 @@ def struct2fdmnes(
     frame: int = 0,
     format: str = "cif",
     filename: Union[None, str] = None,
+    radius: float = 7,
+    edge: str | None = None,
 ) -> dict:
     """convert CIF/XYZ  into a dictionary of {name: text} for FDMNES output files
 
@@ -388,8 +393,14 @@ def struct2fdmnes(
     structs = get_structure_from_text(
         inp, absorber, frame=frame, format=format, filename=filename
     )
-    fout_name = f"{filename.replace('.', '_')}_{absorber.symbol}"
-    fdm = FdmnesXasInput(structs, absorber=absorber, fileout_prefix=fout_name)
-    return {"fdmfile.txt": f"1\n{fout_name}.inp\n", fout_name: fdm.get_input()}
-
-
+    fout_prefix = f"{filename.replace('.', '_')}_{absorber.symbol}"
+    fout_name = f"{fout_prefix}.inp"
+    fdm = FdmnesXasInput(
+        structs,
+        absorber=absorber,
+        frame=frame,
+        edge=edge,
+        radius=radius,
+        fileout_prefix=fout_prefix,
+    )
+    return {"fdmfile.txt": f"1\n{fout_name}\n", fout_name: fdm.get_input()}

--- a/larixite/webapp/webapp.py
+++ b/larixite/webapp/webapp.py
@@ -217,7 +217,8 @@ def cifs(cifid=None):
                                          absorber, edge, cluster_size, with_h, 'fdmnes')
                 config['out_links'] = {}
                 out = struct2fdmnes(config['ciftext'], absorber=absorber,
-                                        filename=ciffile)
+                                    radius=float(cluster_size), edge=edge,
+                                    filename=ciffile)
                 for slabel, text in out.items():
                     link = f'fdmnes_{slabel}'
                     config['out_links'][slabel] = (slabel, cifid, absorber, edge, 0,
@@ -284,7 +285,8 @@ def zipfile(cifid=None, absorber=None, edge='K', cluster_size=7.0,
             zfile.writestr(oname, result)
     elif form == 'fdmnes':
         out = struct2fdmnes(config['ciftext'], absorber=absorber,
-                                filename=f'AMSCD_{cifid}.cif')
+                            radius=float(cluster_size), edge=edge,
+                            filename=f'AMSCD_{cifid}.cif')
         for key, val in out.items():
             zfile.writestr(key, val)
     zfile.close()
@@ -318,9 +320,10 @@ def output(cifid=None, absorber=None, site=1, edge='K', cluster_size=7.0,
                     with_h=with_h, absorber_site=int(site))
     elif form == 'fdmnes':
         xcifid = cifid.replace('.', '_')
-        oname = f'AMSCD_{xcifid}_{absorber}'
+        oname = f'AMSCD_{xcifid}.cif'
         out = struct2fdmnes(config['ciftext'], absorber=absorber,
-                            filename=f'AMSCD_{xcifid}')
+                            radius=float(cluster_size), edge=edge,
+                            filename=oname)
         if fname == 'fdmfile.txt':
             result = out.get(fname, None)
         else:


### PR DESCRIPTION
@newville I was working on some FDMNES fixes during summer 2025, but I forgot to merge them. I think it is safe to merge, but it would be great if you can review it.

Here a summary of changes:
- Fixes #15
- Fix P1 and P-1 space groups calculations
- Update pymatgen* dependencies (-> this should be re-checked to latest pymatgen developments in 2026)
- Fix the webapp naming of output files when external CIF files are loaded

Unless specifically required by users, I would like to work on #4 before releasing `2026.1.0`.
